### PR TITLE
Fixed: npmの依存関係を修正

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "1.0.0",
   "private": true,
   "scripts": {
-    "dev": "nuxt",
-    "build": "nuxt build",
-    "start": "nuxt start",
+    "dev": "NODE_OPTIONS='--openssl-legacy-provider' nuxt",
+    "build": "NODE_OPTIONS='--openssl-legacy-provider' nuxt build",
+    "start": "NODE_OPTIONS='--openssl-legacy-provider' nuxt start",
     "generate": "nuxt generate",
     "heroku-postbuild": "npm run build"
   },


### PR DESCRIPTION
以下のエラーが出てサーバー起動ができないため修正
参考：https://cly7796.net/blog/other/heroku-fails-with-error-0308010c-when-deploying/

```
npm run dev

> front@1.0.0 dev
> nuxt


   ╭───────────────────────────────────────╮
   │                                       │
   │   Nuxt @ v2.15.8                      │
   │                                       │
   │   ▸ Environment: development          │
   │   ▸ Rendering:   server-side          │
   │   ▸ Target:      server               │
   │                                       │
   │   Listening: http://localhost:8080/   │
   │                                       │
   ╰───────────────────────────────────────╯

ℹ Preparing project for development                                                                                                                                             17:16:38
ℹ Initial build may take a while                                                                                                                                                17:16:38
ℹ Discovered Components: .nuxt/components/readme.md                                                                                                                             17:16:38
✔ Builder initialized                                                                                                                                                           17:16:38
✔ Nuxt files generated                                                                                                                                                          17:16:38

● Client █████████████████████████ compiling (0%)


◯ Server


node:internal/crypto/hash:71
  this[kHandle] = new _Hash(algorithm, xofLen);
                  ^

Error: error:0308010C:digital envelope routines::unsupported
    at new Hash (node:internal/crypto/hash:71:19)
    at Object.createHash (node:crypto:133:10)
    at module.exports (/Users/fujiwarayuuji/workspace/Portfolio/work/MyFavoriteAlbums/front/node_modules/webpack/lib/util/createHash.js:135:53)
    at NormalModule._initBuildHash (/Users/fujiwarayuuji/workspace/Portfolio/work/MyFavoriteAlbums/front/node_modules/webpack/lib/NormalModule.js:417:16)
    at handleParseError (/Users/fujiwarayuuji/workspace/Portfolio/work/MyFavoriteAlbums/front/node_modules/webpack/lib/NormalModule.js:471:10)
    at /Users/fujiwarayuuji/workspace/Portfolio/work/MyFavoriteAlbums/front/node_modules/webpack/lib/NormalModule.js:503:5
    at /Users/fujiwarayuuji/workspace/Portfolio/work/MyFavoriteAlbums/front/node_modules/webpack/lib/NormalModule.js:358:12
    at /Users/fujiwarayuuji/workspace/Portfolio/work/MyFavoriteAlbums/front/node_modules/webpack/node_modules/loader-runner/lib/LoaderRunner.js:373:3
    at iterateNormalLoaders (/Users/fujiwarayuuji/workspace/Portfolio/work/MyFavoriteAlbums/front/node_modules/webpack/node_modules/loader-runner/lib/LoaderRunner.js:214:10)
    at Array.<anonymous> (/Users/fujiwarayuuji/workspace/Portfolio/work/MyFavoriteAlbums/front/node_modules/webpack/node_modules/loader-runner/lib/LoaderRunner.js:205:4)
    at Storage.finished (/Users/fujiwarayuuji/workspace/Portfolio/work/MyFavoriteAlbums/front/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:55:16)
    at /Users/fujiwarayuuji/workspace/Portfolio/work/MyFavoriteAlbums/front/node_modules/enhanced-resolve/lib/CachedInputFileSystem.js:91:9
    at /Users/fujiwarayuuji/workspace/Portfolio/work/MyFavoriteAlbums/front/node_modules/graceful-fs/graceful-fs.js:123:16
    at FSReqCallback.readFileAfterClose [as oncomplete] (node:internal/fs/read_file_context:68:3) {
  opensslErrorStack: [ 'error:03000086:digital envelope routines::initialization error' ],
  library: 'digital envelope routines',
  reason: 'unsupported',
  code: 'ERR_OSSL_EVP_UNSUPPORTED'
}

Node.js v18.12.1
```